### PR TITLE
Hide Previous button on the first page and Next button on the last page

### DIFF
--- a/src/Views/Home/Home.js
+++ b/src/Views/Home/Home.js
@@ -63,7 +63,7 @@ const StyledLink = styled(Link)`
 `;
 
 export const Home = () => {
-  const { characters, loading, getNextPage, getPreviousPage } =
+  const { characters, loading, counter, getNextPage, getPreviousPage } =
     useGetCharacters();
 
   return (
@@ -73,8 +73,18 @@ export const Home = () => {
       ) : (
         <Container>
           <ButtonContainer>
-            <Button onClick={() => getPreviousPage()}>{`< Previous`}</Button>
-            <Button onClick={() => getNextPage()}>{`Next >`}</Button>
+            {counter > 1 && (
+              <Button
+                onClick={() => getPreviousPage()}
+                data-testid="previous-button"
+              >{`< Previous`}</Button>
+            )}
+            {counter < 34 && (
+              <Button
+                onClick={() => getNextPage()}
+                data-testid="next-button"
+              >{`Next >`}</Button>
+            )}
           </ButtonContainer>
           <AvatarContainer>
             {characters?.map((character) => {
@@ -93,8 +103,18 @@ export const Home = () => {
             })}
           </AvatarContainer>
           <ButtonContainer>
-            <Button onClick={() => getPreviousPage()}>{`< Previous`}</Button>
-            <Button onClick={() => getNextPage()}>{`Next >`}</Button>
+            {counter > 1 && (
+              <Button
+                onClick={() => getPreviousPage()}
+                data-testid="previous-button"
+              >{`< Previous`}</Button>
+            )}
+            {counter < 34 && (
+              <Button
+                onClick={() => getNextPage()}
+                data-testid="next-button"
+              >{`Next >`}</Button>
+            )}
           </ButtonContainer>
         </Container>
       )}

--- a/src/Views/Home/__tests__/Home.test.js
+++ b/src/Views/Home/__tests__/Home.test.js
@@ -41,4 +41,47 @@ describe("Home", () => {
     );
     expect(getByText("Batman")).toBeInTheDocument();
   });
+
+  it("renders only the `Next` button when rendering the first page", () => {
+    useGetCharacters.mockReturnValue({
+      characters: mockCharacters,
+      counter: 1,
+    });
+
+    renderComponent();
+
+    const nextButton = screen.queryAllByTestId("next-button");
+
+    expect(nextButton.length).toBe(2);
+    expect(screen.queryByTestId("previous-button")).not.toBeInTheDocument();
+  });
+
+  it("renders the `Previous` and the `Next` button when having a counter bigger than 1", () => {
+    useGetCharacters.mockReturnValue({
+      characters: mockCharacters,
+      counter: 2,
+    });
+
+    renderComponent();
+
+    const previoustButton = screen.queryAllByTestId("previous-button");
+    const nextButton = screen.queryAllByTestId("next-button");
+
+    expect(previoustButton.length).toBe(2);
+    expect(nextButton.length).toBe(2);
+  });
+
+  it("renders only the `Previous` buton when rendering the last page", () => {
+    useGetCharacters.mockReturnValue({
+      characters: mockCharacters,
+      counter: 34,
+    });
+
+    renderComponent();
+
+    const previoustButton = screen.queryAllByTestId("previous-button");
+
+    expect(previoustButton.length).toBe(2);
+    expect(screen.queryByTestId("next-button")).not.toBeInTheDocument();
+  });
 });

--- a/src/utils/hooks/useGetCharacters.js
+++ b/src/utils/hooks/useGetCharacters.js
@@ -34,7 +34,7 @@ const useGetCharacters = () => {
     }
   }, [data]);
 
-  return { characters, loading, getNextPage, getPreviousPage };
+  return { characters, loading, counter, getNextPage, getPreviousPage };
 };
 
 export default useGetCharacters;


### PR DESCRIPTION
This avoids the user click the Previous button on the first page, and
click also the Next button on the last page